### PR TITLE
Expose transport ping via client

### DIFF
--- a/client.go
+++ b/client.go
@@ -326,3 +326,8 @@ func (c *Client) SQM() *StreamQueueMessage {
 	}
 	return sqm
 }
+
+// Ping - get status of current connection
+func (c *Client) Ping(ctx context.Context) (*ServerInfo, error) {
+	return c.transport.Ping(ctx)
+}


### PR DESCRIPTION
This small change allows applications using the kubemq-go client to "ping" the server connection as part of their healthcheck process.