### PR TITLE
Handle error message for ReadMessage function

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -56,6 +56,7 @@ func newWebsocketConn(ctx context.Context, uri string, readCh chan string, ready
 		for {
 			_, message, err := c.ReadMessage()
 			if err != nil {
+				errCh <- err
 				return
 			}
 			select {


### PR DESCRIPTION
newWebsocketConn function does not handle the error when ReadMessage function throw error, this pull request have solved that issue